### PR TITLE
add column name when when columns has binary value

### DIFF
--- a/R/makedummies.R
+++ b/R/makedummies.R
@@ -119,6 +119,7 @@ makedummies <- function(dat, basal_level = FALSE, col = NULL, numerical = NULL, 
                     res <- res[,-1]
                 }
                 res <- data.frame(res)
+                colnames(res) <- name
             }
         } else { ## non-factor and non-ordered => as-is
             res <- data.frame(tmp)


### PR DESCRIPTION
When columns has only two values(ex. female or male), "makedummies" make a column named `res`. When columns has over two values, "makedummies" makes the column's name variable name.

I fixed that use variable name when columns has only two values.

# before
![2018-06-19 22 02 38](https://user-images.githubusercontent.com/2999372/41598963-b7582614-740c-11e8-9a1d-f50aaabf2a7c.png)

# after 
![2018-06-19 22 03 30](https://user-images.githubusercontent.com/2999372/41598962-b71e9b88-740c-11e8-84a1-7bd7ee78f4a8.png)