### PR TITLE
allow users to chose basal level

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Imports: tibble
 License: GPL-2
 URL: https://github.com/toshi-ara/makedummies
 BugReports: https://github.com/toshi-ara/makedummies/issues/
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/R/makedummies.R
+++ b/R/makedummies.R
@@ -103,11 +103,19 @@ makedummies <- function(dat, ...) UseMethod("makedummies")
 #' @param basal_level logical
 #'   \describe{
 #'    \item{TRUE}{: include a dummy variable for base group}
-#'    \item{FALSE}{(default) : exclude a dummy variable for base group}
+#'    \item{FALSE}{(default) : exclude the first dummy variable for base group}
+#'    \item{string}{: exclude a selected dummy variable for base group}
 #'   }
 #' @param col Columns vector (all columns are used if \code{NULL} is given)
 #' @param numerical Columns vector converting from \code{factor/ordered} to \code{numeric} (ignore if column is \code{numeric})
 #' @param as.is Columns vector not converting
+#'
+#' @examples
+#' mini_iris <- iris[c(1, 51, 101), 'Species', drop=FALSE]
+#' 
+#' makedummies(mini_iris, basal_level = FALSE) # default
+#' makedummies(mini_iris, basal_level = TRUE)
+#' makedummies(mini_iris, basal_level = "versicolor")
 #'
 #' @export
 #'
@@ -185,8 +193,12 @@ dummy_matrix <- function(dat, basal_level) {
     res[is.na(dat),] <- NA
 
     ## basal_level option => delete basal level
-    if (basal_level == FALSE && (n > 1)) {
-        res <- res[, -1, drop = FALSE]
+    if (n <= 1L) {
+        NULL # Ensure n > 1 to run subsequent conditions
+    } else if (identical(basal_level, FALSE)) {
+        res <- res[, -1L, drop = FALSE]
+    } else if (is.character(basal_level)) {
+        res <- res[, level != match.arg(basal_level, level), drop = FALSE]
     }
 
     if (ncol(res) == 1) {

--- a/man/makedummies.Rd
+++ b/man/makedummies.Rd
@@ -9,13 +9,25 @@
 \usage{
 makedummies(dat, ...)
 
-\method{makedummies}{default}(dat, basal_level = FALSE, col = NULL,
-  numerical = NULL, as.is = NULL, ...)
+\method{makedummies}{default}(
+  dat,
+  basal_level = FALSE,
+  col = NULL,
+  numerical = NULL,
+  as.is = NULL,
+  ...
+)
 
 \method{makedummies}{matrix}(dat, ...)
 
-\method{makedummies}{tbl}(dat, basal_level = FALSE, col = NULL,
-  numerical = NULL, as.is = NULL, ...)
+\method{makedummies}{tbl}(
+  dat,
+  basal_level = FALSE,
+  col = NULL,
+  numerical = NULL,
+  as.is = NULL,
+  ...
+)
 }
 \arguments{
 \item{dat}{data of \code{data.frame}, \code{matrix},
@@ -26,7 +38,8 @@ or \code{tbl} class}
 \item{basal_level}{logical
 \describe{
  \item{TRUE}{: include a dummy variable for base group}
- \item{FALSE}{(default) : exclude a dummy variable for base group}
+ \item{FALSE}{(default) : exclude the first dummy variable for base group}
+ \item{string}{: exclude a selected dummy variable for base group}
 }}
 
 \item{col}{Columns vector (all columns are used if \code{NULL} is given)}
@@ -125,6 +138,12 @@ dat <- data.frame(
 dat
 makedummies(dat, as.is = "x")
 makedummies(dat, as.is = c("x", "y"))
+
+mini_iris <- iris[c(1, 51, 101), 'Species', drop=FALSE]
+
+makedummies(mini_iris, basal_level = FALSE) # default
+makedummies(mini_iris, basal_level = TRUE)
+makedummies(mini_iris, basal_level = "versicolor")
 
 #### 'tibble' class
 if (require(tibble)) {


### PR DESCRIPTION
Following this tweet: https://twitter.com/daihiko/status/1290177195499896832

This PR enables

``` r
library(makedummies)
mini_iris <- iris[c(1, 51, 101), 'Species', drop=FALSE]
makedummies(mini_iris, basal_level = "versicolor")
#>     Species_setosa Species_virginica
#> 1                1                 0
#> 51               0                 0
#> 101              0                 1
```

<sup>Created on 2020-08-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
